### PR TITLE
T6-78: Make color-picker configurable

### DIFF
--- a/pages/component/edit.tsx
+++ b/pages/component/edit.tsx
@@ -1,6 +1,6 @@
 import dynamic from "next/dynamic";
 import React from "react";
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import reactCSS from "reactcss";
 import { SketchPicker, ColorResult } from "react-color";
 import useHostChannel from "@/hooks/useHostChannel";
@@ -34,11 +34,11 @@ export default function Component() {
           return;
         }
         case "field-value": {
-          setColor(message?.content?.color ?? DEFAULT_COLOR);
+          if (message?.content?.color) setColor(message?.content?.color);
           return;
         }
         case "field-config": {
-          setConfig(message.config ?? "");
+          setConfig(message.config ?? "{}");
           return;
         }
       }
@@ -75,6 +75,32 @@ export default function Component() {
       },
     },
   });
+
+  useEffect(() => {
+    const shade = JSON.parse(config).shade ?? "none";
+    if (shade == "red") {
+      setColor({
+        r: 255,
+        g: 0,
+        b: 0,
+        a: 1,
+      });
+    } else if (shade == "blue") {
+      setColor({
+        r: 0,
+        g: 0,
+        b: 255,
+        a: 1,
+      });
+    } else if (shade == "green") {
+      setColor({
+        r: 0,
+        g: 255,
+        b: 0,
+        a: 1,
+      });
+    }
+  }, [config]);
 
   return (
     <div ref={colorRef}>

--- a/pages/component/view.tsx
+++ b/pages/component/view.tsx
@@ -1,5 +1,5 @@
 import dynamic from "next/dynamic";
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import useHostChannel from "@/hooks/useHostChannel";
 
 const ColorSummary = dynamic(() => import("@/components/ColorSummary"), {
@@ -31,11 +31,11 @@ export default function Component() {
           return;
         }
         case "field-value": {
-          setColor(message?.content?.color ?? DEFAULT_COLOR);
+          if (message?.content?.color) setColor(message?.content?.color);
           return;
         }
         case "field-config": {
-          setConfig(message.config ?? "");
+          setConfig(message.config ?? "{}");
           return;
         }
       }
@@ -45,6 +45,32 @@ export default function Component() {
   const handleClick = () => {
     hostChannel.sendMessage({ type: "set:mode", mode: "edit" });
   };
+
+  useEffect(() => {
+    const shade = JSON.parse(config).shade ?? "none";
+    if (shade == "red") {
+      setColor({
+        r: 255,
+        g: 0,
+        b: 0,
+        a: 1,
+      });
+    } else if (shade == "blue") {
+      setColor({
+        r: 0,
+        g: 0,
+        b: 255,
+        a: 1,
+      });
+    } else if (shade == "green") {
+      setColor({
+        r: 0,
+        g: 255,
+        b: 0,
+        a: 1,
+      });
+    }
+  }, [config]);
 
   return (
     <div ref={colorRef}>


### PR DESCRIPTION
TICKET: https://jira.sso.episerver.net/browse/T6-78

## Description

This PR makes the existing color-picker configurable. The initial shade of the color picker can be set from the config page now. Supported shades are `red`, `green` and `blue`

## QA Steps

- Create a color-picker field with config `{ "shade" : "blue" }`. This should set the initial color of the color-picker to blue.
