### PR TITLE
T6-117: Create github action for syncing with code commit repository

### DIFF
--- a/.github/workflows/sync_with_code_commit_repo.yml
+++ b/.github/workflows/sync_with_code_commit_repo.yml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  DEST_REPO: ssh://git-codecommit.us-east-1.amazonaws.com/v1/repos/system-container-ec-77c330ea466411eeae0202420ac8001a 
+  DEST_REPO: ssh://git-codecommit.us-east-1.amazonaws.com/v1/repos/system-container-ec-dd26c60040f011ee8dce863441927fbb 
   DEST_BRANCH: master
   HOST_NAME: git-codecommit.us-east-1.amazonaws.com
 


### PR DESCRIPTION
TICKET: https://jira.sso.episerver.net/browse/DTMTEAM-117

This is a sample action for syncing the `color-picker-editor` repo with the associated AWS code commit repo. 
We are using this repository as an example for other remote fields repos. 


# Sync With Code Commit repo Using Github Action

We are using AWS code commit repo for hosting and deploying our remote fields. But we want that to be transparent to the developers. That is where this action comes in. It will help the team set up a Github repo and corresponding code commit repo once, and after that, they can develop in Github as usual. Whenever a PR is merged on Github, this action will push those changes in the corresponding code commit repository and entire CI/CD pipe (in this case, AWS Cloudformation template to be precise) will trigger automatically.

# Prerequisites

- A code commit repository created with cloud formation template
- A Github repository

After creating the Gihub repository, the action will need some configurations. There are some secrets and variables to be configured. These are as follows:

# Secrets

### SSH_PRIVATE_KEY

In order to access and modify the code commit repository, we need to add `ssh` key to the IAM user associated with the repository. We need to add the public ssh key to the associated IAM user. The github action will need the corresponding private key. `SSH_PRIVATE_KEY` is for this purpose. 

### SSH_KEY_ID

While adding the public ssh key to the associated IAM user, AWS code commit provides an ID which they call SSH_KEY_ID. This ID is also required in order to access the repository. Add that ID as a secret to your Github repo with the name `SSH_KEY_ID` .

# Variables

### DEST_REPO

This is the ssh url of the code commit repository.

### DEST_BRANCH

The branch name in which the change will be pushed. Currently, our cloudformation template lets users push only to the `master` branch. So, `master` is the only valid value for this variable. It might change later.

### HOST_NAME
Get the public ssh keys of remote host `HOST_NAME`. Default given value is `git-codecommit.us-east-1.amazonaws.com`.

For more details, please look into the action code.