### PR TITLE
T6-78: Use config shade only on initial access

### DIFF
--- a/pages/component/edit.tsx
+++ b/pages/component/edit.tsx
@@ -79,6 +79,10 @@ export default function Component() {
   });
 
   useEffect(() => {
+    if (color !== DEFAULT_COLOR) {
+      return;
+    }
+
     const shade = JSON.parse(config).shade ?? "none";
     if (shade == "red") {
       setColor({

--- a/pages/component/view.tsx
+++ b/pages/component/view.tsx
@@ -49,6 +49,10 @@ export default function Component() {
   };
 
   useEffect(() => {
+    if (color !== DEFAULT_COLOR) {
+      return;
+    }
+
     const shade = JSON.parse(config).shade ?? "none";
     if (shade == "red") {
       setColor({


### PR DESCRIPTION
TICKET: [T6-78](https://jira.sso.episerver.net/browse/T6-78)

## Description

Currently the color gets overridden to the shade config's color whenever a component is loaded. Even if its value has been updated afterwards.
This PR makes sure the config is only used until a color is selected in the editor. After that only that color will load.

## QA Steps

- [x] Shade from config is only loaded at the beginning
- [ ] Selected color loads correctly
