### PR TITLE
T6-165: Add config validation endpoint: /api/config/validate

### DIFF
--- a/pages/api/config/validate.ts
+++ b/pages/api/config/validate.ts
@@ -8,7 +8,7 @@ const handler = async (req: NextApiRequest, res: Response) => {
 
   const shade = req.body.shade;
   const validShades = ["red", "green", "blue"];
-  if (shade != null && !validShades.includes(shade)) {
+  if (shade !== undefined && !validShades.includes(shade)) {
     res.status(422).json({
       message: `Shade cannot be ${shade}`,
       details: {


### PR DESCRIPTION
TICKET: T6-165

Related PRs:
- https://github.com/newscred/editor-component-service/pull/38
- https://github.com/newscred/content-repo/pull/301
- https://github.com/newscred/cmp-client/pull/7776

## Description

This PR adds a new `POST /api/config/validate` endpoint.

The endpoint will return
1. `200`: If either `shade` is absent or is one of `red`, `green` or `blue`
2. `422`: If `shade` is not one of `red`, `green` or `blue`
3. `405`: If the http request method is not `POST`

## QA Steps

- [x] Check if endpoint returns correct status code for every case
