### PR TITLE
T6-184: Add POST /api/validate endpoint for component values

### DIFF
--- a/pages/api/validate.ts
+++ b/pages/api/validate.ts
@@ -11,16 +11,12 @@ const handler = async (
 
   const color = req.body.color;
 
-  let errorMessage = null;
   if (typeof color !== "string") {
-    errorMessage = "No 'color' hex string found";
-  } else if (!color.match(/^#[0-9a-f]{6}([0-9a-f]{2})?$/i)) {
-    errorMessage = `'${color}' is not a valid hex color string`;
+    return res.status(422).json({ message: "No 'color' hex string found" });
   }
-
-  if (errorMessage) {
-    res.status(422).json({ message: errorMessage });
-    return;
+  
+  if (!color.match(/^#[0-9a-f]{6}([0-9a-f]{2})?$/i)) {
+    return res.status(422).json({ message: `'${color}' is not a valid hex color string` });
   }
 
   res.status(200).json({ message: "OK" });


### PR DESCRIPTION
TICKET: [T6-184](https://jira.sso.episerver.net/browse/T6-184)

## Description

The endpoint expects a `color` property containing a hex color string. Since our component only sends out 6(rgb) or 8(rgba) digit hex strings, that is what we are validating. We can extend this to 3(rgb) or 4(rgba) or other values if needed later.

## QA Steps

- [ ] Shouldn't accept non POST calls
- [ ] `422` if `color` isn't provided
- [ ] `200` for: `#abcdef`, `#abcdef00`
- [ ] `422` for: `abcdef`, `#abc`, `#redwan` etc...

