### PR TITLE
T6-169: Use `value` nested inside request body

### DIFF
--- a/pages/api/validate.ts
+++ b/pages/api/validate.ts
@@ -9,14 +9,16 @@ const handler = async (
     return;
   }
 
-  const color = req.body.color;
+  const color = req.body?.value?.color;
 
   if (typeof color !== "string") {
     return res.status(422).json({ message: "No 'color' hex string found" });
   }
-  
+
   if (!color.match(/^#[0-9a-f]{6}([0-9a-f]{2})?$/i)) {
-    return res.status(422).json({ message: `'${color}' is not a valid hex color string` });
+    return res
+      .status(422)
+      .json({ message: `'${color}' is not a valid hex color string` });
   }
 
   res.status(200).json({ message: "OK" });


### PR DESCRIPTION
TICKET: [T6-169](https://jira.sso.episerver.net/browse/T6-169)

## Description

We're expecting the request body of the `/validate` endpoint to be
```
{ value: ValueType, config: ConfigType }
```

This nesting was added because value validation may need the config too. 

## QA Steps

- [ ] Should use `value` from within the body
