### PR TITLE
T6-243: Ask for mode from the host

### DIFF
--- a/helpers/types.ts
+++ b/helpers/types.ts
@@ -1,3 +1,4 @@
+export type Mode = "view" | "edit";
 export type Color = string;
 
 export type Config = {
@@ -16,7 +17,7 @@ export type HostMessage =
     }
   | {
       type: "mode";
-      data: "view" | "edit";
+      data: Mode;
     };
 
 export type ComponentMessage =
@@ -28,5 +29,5 @@ export type ComponentMessage =
       data: { color: Color } | undefined;
     }
   | { type: "get:mode" }
-  | { type: "set:mode"; data: "view" | "edit" }
+  | { type: "set:mode"; data: Mode}
   | { type: "set:style"; data: { height: string } };

--- a/helpers/types.ts
+++ b/helpers/types.ts
@@ -13,6 +13,10 @@ export type HostMessage =
   | {
       type: "field-config";
       data: Config;
+    }
+  | {
+      type: "mode";
+      data: "view" | "edit";
     };
 
 export type ComponentMessage =

--- a/pages/component/edit.tsx
+++ b/pages/component/edit.tsx
@@ -30,6 +30,9 @@ export default function Component() {
               height: "350px",
             },
           });
+          hostChannel.sendMessage({
+            type: "get:mode",
+          });
           return;
         }
         case "field-value": {
@@ -38,6 +41,10 @@ export default function Component() {
         }
         case "field-config": {
           setConfig(message.data ?? {});
+          return;
+        }
+        case "mode": {
+          console.log("The current mode is", message.data);
           return;
         }
       }

--- a/pages/component/edit.tsx
+++ b/pages/component/edit.tsx
@@ -44,7 +44,7 @@ export default function Component() {
           return;
         }
         case "mode": {
-          console.log("The current mode is", message.data);
+          console.log("From edit component: The current mode is", message.data);
           return;
         }
       }

--- a/pages/component/view.tsx
+++ b/pages/component/view.tsx
@@ -25,6 +25,9 @@ export default function Component() {
               height: "50px",
             },
           });
+          hostChannel.sendMessage({
+            type: "get:mode",
+          });
           return;
         }
         case "field-value": {
@@ -33,6 +36,10 @@ export default function Component() {
         }
         case "field-config": {
           setConfig(message.data ?? {});
+          return;
+        }
+        case "mode": {
+          console.log("The current mode is", message.data);
           return;
         }
       }

--- a/pages/component/view.tsx
+++ b/pages/component/view.tsx
@@ -39,7 +39,7 @@ export default function Component() {
           return;
         }
         case "mode": {
-          console.log("The current mode is", message.data);
+          console.log("From view component: The current mode is", message.data);
           return;
         }
       }


### PR DESCRIPTION
TICKET: https://jira.sso.episerver.net/DTMTEAM-243

Related PRs:
- https://github.com/newscred/cmp-client/pull/8154

## Description
This PR asks the remote field host (cmp) for the current mode that the editor is in. The possible values are `view`, `edit`.
## QA Steps

#### Before Merging

- [x] While loading a remote field into a content, you can log the `mode` value the remote field got from the `get:mode` call and check if it is exactly what you expect.

#### After Deployed

- [ ] <!-- step to test change -->
