### PR TITLE
T6-370: Update codecommit repo ssh url

### DIFF
--- a/.github/workflows/sync_with_code_commit_repo.yml
+++ b/.github/workflows/sync_with_code_commit_repo.yml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  DEST_REPO: ssh://git-codecommit.us-east-1.amazonaws.com/v1/repos/system-container-ec-dd26c60040f011ee8dce863441927fbb 
+  DEST_REPO: ssh://git-codecommit.us-east-1.amazonaws.com/v1/repos/system-container_ec-dd26c60040f011ee8dce863441927fbb
   DEST_BRANCH: master
   HOST_NAME: git-codecommit.us-east-1.amazonaws.com
 

--- a/.github/workflows/sync_with_code_commit_repo.yml
+++ b/.github/workflows/sync_with_code_commit_repo.yml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  DEST_REPO: ssh://git-codecommit.us-east-1.amazonaws.com/v1/repos/system-container_ec-dd26c60040f011ee8dce863441927fbb
+  DEST_REPO: ssh://git-codecommit.us-east-1.amazonaws.com/v1/repos/system-container_ec-6b8235302aba11ee80f7ba98a1d93d1a
   DEST_BRANCH: master
   HOST_NAME: git-codecommit.us-east-1.amazonaws.com
 


### PR DESCRIPTION
TICKET: [T6-370](https://jira.sso.episerver.net/browse/T6-370)

Related PRs:
- https://github.com/newscred/container-pipeline/pull/101

## Description

This PR updates the codecommit repo ssh url.

Due to some architectural changes, the codecommit repo ssh url has changed. In the `system-container-ec-dd26c60040f011ee8dce863441927fbb` part of the previous url, `system-container` is the namespace name and `ec-dd26c60040f011ee8dce863441927fbb` is the pipeline name. The separator between these two names were hyphen before. In the updated url, the separator is underscore.

## QA Steps

- [ ] The github action should update the correct repo
