### PR TITLE
T6-438: Add userId to field Context type

### DIFF
--- a/helpers/types.ts
+++ b/helpers/types.ts
@@ -8,6 +8,7 @@ export type Config = {
 export type Context = {
   taskId: string;
   contentGuid: string;
+  userId: string;
 };
 
 export type HostMessage =

--- a/pages/component/edit.tsx
+++ b/pages/component/edit.tsx
@@ -49,8 +49,7 @@ export default function Component() {
           return;
         }
         case "field-context": {
-          const { taskId, contentGuid } = message.data;
-          console.log(`Task ID ${taskId} & Content GUID ${contentGuid}`);
+          console.log("Context: ", message.data);
           return;
         }
       }

--- a/pages/component/view.tsx
+++ b/pages/component/view.tsx
@@ -43,8 +43,7 @@ export default function Component() {
           return;
         }
         case "field-context": {
-          const { taskId, contentGuid } = message.data;
-          console.log(`Task ID ${taskId} & Content GUID ${contentGuid}`);
+          console.log("Context: ", message.data);
           return;
         }
       }


### PR DESCRIPTION
TICKET: [T6-438](https://jira.sso.episerver.net/browse/T6-438)

Related PRs:
- https://github.com/newscred/cmp-client/pull/9093

## Description

This PR adds a `userId` field to the `Context` type and logs the entire `context` object once received.

## QA Steps

- [x] Load the color picker rf in a task content
- [x] The context logged to console should include the `userId`
